### PR TITLE
feat: promote Create Your Item with CTA banner and page improvements

### DIFF
--- a/src/components/NavHeader.astro
+++ b/src/components/NavHeader.astro
@@ -8,6 +8,7 @@
 
     <ul class="nav-links" role="list">
       <li><a class="nav-link" href="/">Catalog</a></li>
+      <li><a class="nav-link" href="/create">Create</a></li>
       <li>
         <a class="nav-link nav-cart" href="/cart">
           Cart

--- a/src/pages/create.astro
+++ b/src/pages/create.astro
@@ -73,7 +73,7 @@ import '../styles/global.css';
         </button>
       </div>
 
-      <a class="back-link" href="/catalog">&larr; Back to Catalog</a>
+      <a class="back-link" href="/">&larr; Back to Catalog</a>
     </div>
   </main>
 </body>
@@ -101,6 +101,20 @@ import '../styles/global.css';
 
   .create-state {
     text-align: center;
+    opacity: 0;
+    transform: translateY(var(--space-3));
+    transition: opacity 0.4s ease, transform 0.4s ease;
+    pointer-events: none;
+  }
+
+  .create-state.is-visible {
+    opacity: 1;
+    transform: translateY(0);
+    pointer-events: auto;
+  }
+
+  .create-state[hidden] {
+    display: none;
   }
 
   /* ── Form State ──────────────────────────────────────────────────────── */
@@ -228,10 +242,10 @@ import '../styles/global.css';
     display: flex;
     flex-direction: column;
     background: var(--color-bg-mid);
-    border: var(--space-1) solid var(--color-primary);
+    border: var(--space-1) solid var(--color-accent);
     border-radius: var(--border-radius);
     overflow: hidden;
-    box-shadow: var(--space-1) var(--space-1) 0 var(--color-moss);
+    box-shadow: var(--space-1) var(--space-1) 0 var(--color-oak);
     margin-bottom: var(--space-5);
   }
 
@@ -265,7 +279,7 @@ import '../styles/global.css';
 
   .result-name {
     font-family: var(--font-heading);
-    font-size: var(--text-sm);
+    font-size: var(--text-xl);
     color: var(--color-text-light);
     margin: 0;
     line-height: 1.4;
@@ -314,6 +328,23 @@ import '../styles/global.css';
   .result-cart-btn--in-cart:hover,
   .result-cart-btn--in-cart:focus-visible {
     background: var(--color-stone);
+  }
+
+  /* ── Result Card Entrance Animation ─────────────────────────────────── */
+
+  @keyframes card-entrance {
+    from {
+      opacity: 0;
+      transform: translateY(var(--space-5)) scale(0.95);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0) scale(1);
+    }
+  }
+
+  .is-visible .result-card {
+    animation: card-entrance 0.6s ease-out 0.1s both;
   }
 
   /* ── Back Link ───────────────────────────────────────────────────────── */
@@ -411,12 +442,35 @@ import '../styles/global.css';
   const resultSubtitle = document.getElementById('result-subtitle') as HTMLElement;
   const addToCartBtn = document.getElementById('add-to-cart-btn') as HTMLButtonElement;
 
+  // Initialize: show form state with animation
+  stateForm.hidden = false;
+  stateForm.classList.add('is-visible');
+
   // ── State management ──────────────────────────────────────────────────
 
   function showState(state: 'form' | 'loading' | 'success'): void {
-    stateForm.hidden = state !== 'form';
-    stateLoading.hidden = state !== 'loading';
-    stateSuccess.hidden = state !== 'success';
+    const states = { form: stateForm, loading: stateLoading, success: stateSuccess };
+    Object.entries(states).forEach(([key, el]) => {
+      if (key === state) {
+        el.hidden = false;
+        // Use requestAnimationFrame to ensure hidden is removed before adding class
+        requestAnimationFrame(() => {
+          requestAnimationFrame(() => {
+            el.classList.add('is-visible');
+          });
+        });
+      } else {
+        el.classList.remove('is-visible');
+        // Wait for transition to complete before hiding
+        const handler = () => {
+          el.hidden = true;
+          el.removeEventListener('transitionend', handler);
+        };
+        el.addEventListener('transitionend', handler);
+        // Fallback: hide after transition duration if transitionend doesn't fire
+        setTimeout(() => { el.hidden = true; }, 500);
+      }
+    });
   }
 
   // ── Loading messages ──────────────────────────────────────────────────

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -37,9 +37,26 @@ import addons from '../data/addons.json';
         <button class="filter-btn" data-type="mob" type="button" aria-pressed="false">Mob</button>
         <button class="filter-btn" data-type="item" type="button" aria-pressed="false">Item</button>
         <button class="filter-btn" data-type="block" type="button" aria-pressed="false">Block</button>
-        <button class="filter-btn" data-type="system" type="button" aria-pressed="false">System</button>
       </div>
     </div>
+
+    <!-- ── Create Your Item CTA Banner ────────────────────────────────────── -->
+    <a class="cta-banner" href="/create" aria-label="Create your own addon">
+      <div class="cta-stars" aria-hidden="true">
+        <span class="star star-1"></span>
+        <span class="star star-2"></span>
+        <span class="star star-3"></span>
+        <span class="star star-4"></span>
+        <span class="star star-5"></span>
+        <span class="star star-6"></span>
+        <span class="star star-7"></span>
+        <span class="star star-8"></span>
+      </div>
+      <div class="cta-content">
+        <h2 class="cta-heading">MAKE YOUR ITEM</h2>
+        <span class="cta-link">Start Creating &rarr;</span>
+      </div>
+    </a>
 
     <!-- ── Addon Card Grid ──────────────────────────────────────────────── -->
     <div class="card-grid">
@@ -278,6 +295,102 @@ import addons from '../data/addons.json';
     background: var(--color-stone);
   }
 
+  /* ── CTA Banner ─────────────────────────────────────────────────────── */
+
+  .cta-banner {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--color-bg-dark);
+    border: var(--space-1) solid var(--color-border);
+    border-radius: var(--border-radius);
+    padding: var(--space-7) var(--space-4);
+    margin-bottom: var(--space-4);
+    overflow: hidden;
+    text-decoration: none;
+    cursor: pointer;
+    transition: border-color 0.3s;
+  }
+
+  .cta-banner:hover {
+    border-color: var(--color-accent);
+  }
+
+  .cta-stars {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+  }
+
+  .star {
+    position: absolute;
+    width: var(--space-1);
+    height: var(--space-1);
+    background: var(--color-text-light);
+    border-radius: var(--border-radius);
+    opacity: 0;
+    animation: twinkle 3s ease-in-out infinite;
+  }
+
+  .star-1 { top: 15%; left: 10%; animation-delay: 0s; }
+  .star-2 { top: 25%; left: 80%; animation-delay: 0.5s; }
+  .star-3 { top: 60%; left: 25%; animation-delay: 1s; }
+  .star-4 { top: 70%; left: 65%; animation-delay: 1.5s; }
+  .star-5 { top: 40%; left: 45%; animation-delay: 0.3s; }
+  .star-6 { top: 80%; left: 90%; animation-delay: 2s; }
+  .star-7 { top: 10%; left: 55%; animation-delay: 0.8s; }
+  .star-8 { top: 50%; left: 5%; animation-delay: 1.3s; }
+
+  @keyframes twinkle {
+    0%, 100% { opacity: 0; transform: scale(0.5); }
+    50% { opacity: 0.9; transform: scale(1.2); }
+  }
+
+  .cta-content {
+    position: relative;
+    z-index: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--space-3);
+    text-align: center;
+  }
+
+  .cta-heading {
+    font-family: var(--font-heading);
+    font-size: var(--text-2xl);
+    color: var(--color-text-light);
+    margin: 0;
+    letter-spacing: var(--space-1);
+    text-shadow: 0 0 var(--space-4) rgba(240, 192, 64, 0.3);
+  }
+
+  .cta-link {
+    font-family: var(--font-heading);
+    font-size: var(--text-sm);
+    color: var(--color-accent);
+    background: transparent;
+    border: var(--space-1) solid var(--color-accent);
+    border-radius: var(--border-radius);
+    padding: var(--space-2) var(--space-5);
+    transition: box-shadow 0.3s, background 0.15s;
+  }
+
+  .cta-banner:hover .cta-link {
+    background: var(--color-accent);
+    color: var(--color-text-dark);
+    box-shadow:
+      0 0 var(--space-3) var(--color-accent),
+      0 0 var(--space-6) rgba(240, 192, 64, 0.4);
+    animation: glow-pulse 1.5s ease-in-out infinite;
+  }
+
+  @keyframes glow-pulse {
+    0%, 100% { box-shadow: 0 0 var(--space-3) var(--color-accent), 0 0 var(--space-6) rgba(240, 192, 64, 0.4); }
+    50% { box-shadow: 0 0 var(--space-5) var(--color-accent), 0 0 var(--space-8) rgba(240, 192, 64, 0.6); }
+  }
+
   /* ── No Results Message ─────────────────────────────────────────────── */
 
   .no-results {
@@ -325,6 +438,19 @@ import addons from '../data/addons.json';
 
     .card-desc {
       font-size: var(--text-xs);
+    }
+
+    .cta-banner {
+      padding: var(--space-5) var(--space-3);
+    }
+
+    .cta-heading {
+      font-size: var(--text-lg);
+    }
+
+    .cta-link {
+      font-size: var(--text-xs);
+      padding: var(--space-2) var(--space-3);
     }
 
   }


### PR DESCRIPTION
## Summary

- Add animated "MAKE YOUR ITEM" CTA banner with twinkling stars between filter bar and card grid in catalog
- Remove "System" filter button (Weather Control System addon remains visible under "All")
- Add "Create" nav link to NavHeader (was missing), fix broken `/catalog` back-link to `/`
- Add smooth fade/slide CSS transitions between create page states (form → loading → success)
- Improve success state: gold accent border, larger item name (`--text-xl`), card entrance animation

Closes #19

## Test plan

- [ ] Verify "Create" nav link navigates to `/create`
- [ ] Verify "Back to Catalog" link on create page navigates to `/`
- [ ] Verify "System" filter button is absent; Weather Control System visible under "All"
- [ ] Verify CTA banner appears between filters and grid with animated stars
- [ ] Verify CTA banner hover shows gold glow effect
- [ ] Verify create page states animate smoothly (not instant snap)
- [ ] Verify success state result card has entrance animation and gold border
- [ ] Verify responsive layout at 375px and 1280px (no overflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)